### PR TITLE
test(git): add test coverage for `--tag` option

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -16,7 +16,7 @@ exports.getCommits = function (options) {
   options = options || {};
   return new Bluebird(function (resolve) {
     if (options.tag) {
-      return resolve(options.args[0]);
+      return resolve(options.tag);
     }
     return resolve(CP.execAsync('git describe --tags --abbrev=0'));
   })

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -39,7 +39,20 @@ describe('git', function () {
       });
     });
 
-    it('errs if there are no commits yet', function () {
+    it('uses custom revision range if `-t` / `--tag` option was used', function () {
+      Sinon.stub(CP, 'execAsync')
+        .onFirstCall().returns(Bluebird.resolve(VALID_COMMITS));
+
+      var tagRange = 'aabbccdd..eeffgghh';
+
+      return Git.getCommits({ tag: tagRange })
+      .then(function () {
+        CP.execAsync.firstCall.calledWithMatch(tagRange);
+        CP.execAsync.restore();
+      });
+    });
+
+    it('errors if there are no commits yet', function () {
       Sinon.stub(CP, 'execAsync')
         .onFirstCall().returns(Bluebird.resolve('v1.2.3'))
         .onSecondCall().returns(Bluebird.reject());


### PR DESCRIPTION
fixed `args` usage + added test coverage